### PR TITLE
fix: validate required file fields on service request

### DIFF
--- a/src/components/ListingDetail.tsx
+++ b/src/components/ListingDetail.tsx
@@ -144,8 +144,14 @@ export default function ListingDetail({ id, walletAddress, signer }: Props) {
       if (hasSchema) {
         for (const field of listing.input_schema!) {
           const val = formValues[field.name];
-          if (field.required && field.type !== "file") {
-            if (!val || (typeof val === "string" && !val.trim())) {
+          if (field.required) {
+            if (field.type === "file") {
+              if (!(val instanceof File)) {
+                setRequestError(`${field.label} is required`);
+                setRequesting(false);
+                return;
+              }
+            } else if (!val || (typeof val === "string" && !val.trim())) {
               setRequestError(`${field.label} is required`);
               setRequesting(false);
               return;


### PR DESCRIPTION
## What changed
- Required file fields in the marketplace listing request form now block submission if no file has been selected
- Previously, the validation guard had `field.type !== "file"` which silently skipped required file field checks