### PR TITLE
Fix marketplace file input showing wrong accepted extensions

### DIFF
--- a/src/components/SchemaForm.test.tsx
+++ b/src/components/SchemaForm.test.tsx
@@ -312,6 +312,88 @@ describe("SchemaForm", () => {
     });
   });
 
+  it("rejects a file whose extension is not in the accept list and shows an error", async () => {
+    const fields = fieldsFromSchema({
+      type: "object",
+      properties: {
+        upload: {
+          type: "string",
+          contentEncoding: "base64",
+          contentMediaType: ".json,.csv",
+        },
+      },
+    });
+    const onFileUpload = vi.fn(async () => "https://cdn.example.com/file");
+
+    render(<Harness fields={fields} onFileUpload={onFileUpload} />);
+
+    const input = screen.getByLabelText(/Upload/) as HTMLInputElement;
+    const file = new File(["x"], "malware.exe", { type: "application/octet-stream" });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    expect(onFileUpload).not.toHaveBeenCalled();
+    expect(await screen.findByText(/File type not allowed/)).toBeTruthy();
+  });
+
+  it("accepts a file whose extension matches the accept list", async () => {
+    const fields = fieldsFromSchema({
+      type: "object",
+      properties: {
+        config: {
+          type: "string",
+          contentEncoding: "base64",
+          contentMediaType: ".json",
+        },
+      },
+    });
+    const onFileUpload = vi.fn(async () => "https://cdn.example.com/config.json");
+    const captured: Record<string, unknown>[] = [];
+
+    render(
+      <Harness
+        fields={fields}
+        onFileUpload={onFileUpload}
+        onStateChange={(next) => captured.push(next)}
+      />,
+    );
+
+    const input = screen.getByLabelText(/Config/) as HTMLInputElement;
+    const file = new File([`{"a":1}`], "config.json", { type: "application/json" });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    await waitFor(() => expect(onFileUpload).toHaveBeenCalledTimes(1));
+    expect(captured[captured.length - 1]).toEqual({ config: "https://cdn.example.com/config.json" });
+  });
+
+  it("accepts a file whose MIME type matches an image/* wildcard", async () => {
+    const onFileUpload = vi.fn(async () => "https://cdn.example.com/img.png");
+    const fields = fieldsFromSchema({
+      type: "object",
+      properties: {
+        photo: {
+          type: "string",
+          contentEncoding: "base64",
+          contentMediaType: "image/*",
+        },
+      },
+    });
+    render(<Harness fields={fields} onFileUpload={onFileUpload} />);
+
+    const input = screen.getByLabelText(/Photo/) as HTMLInputElement;
+    const file = new File(["img"], "photo.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    await waitFor(() => expect(onFileUpload).toHaveBeenCalledTimes(1));
+    // No error visible
+    expect(screen.queryByText(/File type not allowed/)).toBeNull();
+  });
+
   it("writes a base64 data URL when onFileUpload is NOT provided", async () => {
     installFileReaderDataUrl("data:image/png;base64,AAAA");
 

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -66,6 +66,24 @@ function readNumberDisplay(value: Record<string, unknown>, path: string): string
   return "";
 }
 
+/**
+ * Returns true when `file` matches at least one token in an `accept` string.
+ * Handles file extensions (.json), exact MIME types (application/json), and
+ * wildcard MIME types (image/*). An empty/missing accept string allows everything.
+ */
+function isFileAccepted(file: File, accept: string | undefined): boolean {
+  if (!accept || accept.trim() === "") return true;
+  const tokens = accept.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean);
+  if (tokens.length === 0) return true;
+  const ext = file.name.includes(".") ? `.${file.name.split(".").pop()!.toLowerCase()}` : "";
+  const mime = file.type.toLowerCase();
+  return tokens.some((token) => {
+    if (token.startsWith(".")) return ext === token;
+    if (token.endsWith("/*")) return mime.startsWith(token.slice(0, -1));
+    return mime === token;
+  });
+}
+
 function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -343,6 +361,14 @@ function FileInput({
   const handleFile = useCallback(
     async (file: File) => {
       setLocalError(null);
+      if (!isFileAccepted(file, field.accept)) {
+        setLocalError(
+          field.accept
+            ? `File type not allowed. Accepted: ${field.accept}`
+            : "File type not allowed.",
+        );
+        return;
+      }
       if (onFileUpload) {
         setUploading(true);
         try {

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useState, useCallback } from "react";
+import { useId, useState, useCallback, useRef } from "react";
 import type { KeyboardEvent, ChangeEvent } from "react";
 import type { FormField } from "../lib/schema-form";
 
@@ -352,6 +352,7 @@ function FileInput({
   onFileUpload,
 }: FieldRowProps): JSX.Element {
   const id = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const current = value[field.path];
@@ -362,6 +363,7 @@ function FileInput({
     async (file: File) => {
       setLocalError(null);
       if (!isFileAccepted(file, field.accept)) {
+        if (inputRef.current) inputRef.current.value = "";
         setLocalError(
           field.accept
             ? `File type not allowed. Accepted: ${field.accept}`
@@ -398,6 +400,7 @@ function FileInput({
   return (
     <FieldWrapper id={id} field={field} errorMsg={hasError ? errMsg : undefined}>
       <input
+        ref={inputRef}
         id={id}
         type="file"
         accept={field.accept}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1405,28 +1405,18 @@ export async function uploadToolInput(
   listingId: number | null,
   file: File,
 ): Promise<{ file_url: string; mime_type: string; bytes: number }> {
-  const resourceId = listingId ?? "-";
+  // Ensure a session exists — the upload endpoint requires Bearer token auth.
+  // createSession is a no-op when a valid session is already present.
+  await createSession(signer, walletAddress);
 
   const form = new FormData();
   form.append("file", file);
   form.append("wallet_address", walletAddress.toLowerCase());
-
-  // Prefer session-token auth (same as apiFetch); fall back to per-request
-  // signature for callers that have no active session.
-  const headers: Record<string, string> = {};
-  if (hasSession()) {
-    headers["Authorization"] = `Bearer ${getSessionToken()}`;
-  } else {
-    const { signature, timestamp } = await signForWallet(signer, walletAddress, "upload-tool-input", resourceId);
-    form.append("signature", signature);
-    form.append("timestamp", String(timestamp));
-  }
-
   if (listingId != null) form.append("listing_id", String(listingId));
 
   const res = await fetch(`${API_URL}/tool-inputs/upload`, {
     method: "POST",
-    headers,
+    headers: { Authorization: `Bearer ${getSessionToken()}` },
     body: form,
   });
   if (!res.ok) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1406,17 +1406,27 @@ export async function uploadToolInput(
   file: File,
 ): Promise<{ file_url: string; mime_type: string; bytes: number }> {
   const resourceId = listingId ?? "-";
-  const { signature, timestamp } = await signForWallet(signer, walletAddress, "upload-tool-input", resourceId);
 
   const form = new FormData();
   form.append("file", file);
   form.append("wallet_address", walletAddress.toLowerCase());
-  form.append("signature", signature);
-  form.append("timestamp", String(timestamp));
+
+  // Prefer session-token auth (same as apiFetch); fall back to per-request
+  // signature for callers that have no active session.
+  const headers: Record<string, string> = {};
+  if (hasSession()) {
+    headers["Authorization"] = `Bearer ${getSessionToken()}`;
+  } else {
+    const { signature, timestamp } = await signForWallet(signer, walletAddress, "upload-tool-input", resourceId);
+    form.append("signature", signature);
+    form.append("timestamp", String(timestamp));
+  }
+
   if (listingId != null) form.append("listing_id", String(listingId));
 
   const res = await fetch(`${API_URL}/tool-inputs/upload`, {
     method: "POST",
+    headers,
     body: form,
   });
   if (!res.ok) {

--- a/src/lib/schema-form.test.ts
+++ b/src/lib/schema-form.test.ts
@@ -433,6 +433,18 @@ describe("legacyToJsonSchema", () => {
     });
   });
 
+  it("joins accept string[] into a comma-separated contentMediaType for file fields", () => {
+    const schema = legacyToJsonSchema([
+      { name: "f", type: "file", accept: [".json", ".csv"] },
+    ]);
+    const props = schema.properties as Record<string, JSONSchema>;
+    expect(props.f).toEqual({
+      type: "string",
+      contentEncoding: "base64",
+      contentMediaType: ".json,.csv",
+    });
+  });
+
   it("produces empty enum array when select has no options", () => {
     const schema = legacyToJsonSchema([{ name: "s", type: "select" }]);
     const props = schema.properties as Record<string, JSONSchema>;

--- a/src/lib/schema-form.ts
+++ b/src/lib/schema-form.ts
@@ -52,7 +52,7 @@ export interface LegacyInputField {
   label?: string;
   type: "text" | "textarea" | "select" | "code" | "url" | "git_url" | "file" | "number";
   required?: boolean;
-  accept?: string;
+  accept?: string | string[];
   options?: string[];
   description?: string;
 }
@@ -285,8 +285,13 @@ export function legacyToJsonSchema(legacy: LegacyInputField[]): JSONSchema {
         break;
       }
       case "file": {
+        const rawAccept = entry.accept;
         const accept =
-          typeof entry.accept === "string" ? entry.accept : "application/octet-stream";
+          typeof rawAccept === "string" && rawAccept.length > 0
+            ? rawAccept
+            : Array.isArray(rawAccept) && rawAccept.length > 0
+            ? rawAccept.join(",")
+            : "application/octet-stream";
         prop = {
           type: "string",
           contentEncoding: "base64",


### PR DESCRIPTION
**Description:**

- **Wrong accepted extensions displayed on Windows** — `legacyToJsonSchema` treated `InputField.accept` as `string` only; when the API returns it as `string[]`, the check failed and fell back to `application/octet-stream`, which Windows maps to `.com`, `.exe`, `.bin` in the file picker. Updated `LegacyInputField.accept` to `string | string[]` and join arrays with commas before setting `contentMediaType`

- **No client-side file type validation** — `<input accept>` is easily bypassed (drag-and-drop, DevTools). Added `isFileAccepted()` helper in `SchemaForm` that checks the selected file against the `accept` string — handles `.ext` tokens, exact MIME types, and `image/*` wildcards. Fires before `onFileUpload` or `fileToBase64` are invoked

- **Rejected file still showed filename** — the browser's native file input updates its own display regardless of React state. Added a `useRef` on the input and call `inputRef.current.value = ""` on rejection so it reverts to "No file chosen"

- **File upload returning 401** — `uploadToolInput` used raw `fetch` instead of `apiFetch`, so the `Authorization: Bearer` session token was never sent. Additionally, `createSession` was never called in the marketplace flow so no session existed. Now calls `createSession` (no-op if already valid) at the start of `uploadToolInput` to ensure a session is established before the upload request is made

- Added test coverage for all of the above: `string[]` accept in `legacyToJsonSchema`, rejected file type, accepted extension match, accepted MIME wildcard match