### PR TITLE
fix: unblock Confirm & Fund button stuck on 'Funding...'

### DIFF
--- a/src/components/JobQueue.tsx
+++ b/src/components/JobQueue.tsx
@@ -89,7 +89,7 @@ export default function JobQueue({ walletAddress, signer, onAction }: Props) {
   const [fundingDetails, setFundingDetails] = useState<{ price: string; fee: string; total: string; feeModel: string; providerFee: string } | null>(null);
   const fundingRef = useRef(false);
   const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; }; }, []);
 
   const fetchJobs = useCallback(async (p: number, silent = false) => {
     if (!silent) setLoading(true);


### PR DESCRIPTION
## What changed
- Fixed `mountedRef` in `JobQueue` to reset to `true` on mount, not just on cleanup
- React 18 Strict Mode double-invokes effects (mount → cleanup → remount), which left `mountedRef.current` permanently `false` after the initial lifecycle
- This caused the `finally` block's `setActing(null)` to never run, freezing the **Confirm & Fund** button on "Funding..." indefinitely with no way to recover
- Same bug also silently swallowed error messages in the `catch` block during the fund flow