### PR TITLE
fix: load managed agents

### DIFF
--- a/src/app/tools/publish/page.tsx
+++ b/src/app/tools/publish/page.tsx
@@ -8,6 +8,7 @@ import Footer from "@/components/Footer";
 import ToolPublishWizard from "@/components/ToolPublishWizard";
 import AgentRegistration from "@/components/AgentRegistration";
 import { getAgentOnChain } from "@/lib/contracts";
+import { getHostedAgents, hasSession, type HostedAgentSummary } from "@/lib/api";
 
 interface AgentInfo {
   agentId: number;
@@ -17,12 +18,24 @@ interface AgentInfo {
   isRegistered: boolean;
 }
 
+const OWNER_OPTION = "__owner__";
+
+function truncAddr(addr: string) {
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
 function PublishContent() {
   const searchParams = useSearchParams();
   const [address, setAddress] = useState<string | null>(null);
   const [signer, setSigner] = useState<JsonRpcSigner | null>(null);
   const [agent, setAgent] = useState<AgentInfo | null>(null);
   const [agentLoading, setAgentLoading] = useState(false);
+
+  const [hostedAgents, setHostedAgents] = useState<HostedAgentSummary[]>([]);
+  const [hostedLoading, setHostedLoading] = useState(false);
+  const [hostedError, setHostedError] = useState<string | null>(null);
+  const [hostedLoaded, setHostedLoaded] = useState(false);
+  const [selected, setSelected] = useState<string>(OWNER_OPTION);
 
   const fetchAgent = useCallback(async (addr: string) => {
     setAgentLoading(true);
@@ -36,27 +49,62 @@ function PublishContent() {
     }
   }, []);
 
-  const handleConnect = useCallback(
-    (addr: string, s: JsonRpcSigner) => {
-      setAddress(addr);
-      setSigner(s);
-    },
-    [],
-  );
+  const fetchHosted = useCallback(async (addr: string, s: JsonRpcSigner) => {
+    setHostedLoading(true);
+    setHostedError(null);
+    try {
+      const agents = await getHostedAgents(s, addr);
+      setHostedAgents(agents.filter((a) => a.active));
+      setHostedLoaded(true);
+    } catch (err) {
+      setHostedError((err as Error).message || "Failed to load hosted agents");
+    } finally {
+      setHostedLoading(false);
+    }
+  }, []);
+
+  const handleConnect = useCallback((addr: string, s: JsonRpcSigner) => {
+    setAddress(addr);
+    setSigner(s);
+  }, []);
   const handleDisconnect = useCallback(() => {
     setAddress(null);
     setSigner(null);
     setAgent(null);
+    setHostedAgents([]);
+    setHostedLoaded(false);
+    setHostedError(null);
+    setSelected(OWNER_OPTION);
   }, []);
 
   useEffect(() => {
     if (address) fetchAgent(address);
   }, [address, fetchAgent]);
 
+  // Lazy-load hosted agents if the user already has a session (e.g. came from
+  // /dashboard). Otherwise wait for an explicit click so we don't force a
+  // signature on users who just want to publish under their own wallet.
+  useEffect(() => {
+    if (address && signer && hasSession() && !hostedLoaded) {
+      fetchHosted(address, signer);
+    }
+  }, [address, signer, hostedLoaded, fetchHosted]);
+
   const rawEdit = searchParams.get("edit");
   const editListingId = rawEdit && !Number.isNaN(Number(rawEdit)) ? Number(rawEdit) : null;
 
-  const isRegisteredAndActive = agent?.isRegistered && agent?.active;
+  const isRegisteredAndActive = !!(agent?.isRegistered && agent?.active);
+  const publishingAsOwner = selected === OWNER_OPTION;
+  const publishAsWallet = publishingAsOwner
+    ? address
+    : hostedAgents.find((a) => a.wallet_address.toLowerCase() === selected)?.wallet_address ?? address;
+
+  // Registration gate only applies when publishing under the owner wallet.
+  // Hosted agents are auto-registered on-chain at deploy time.
+  const showOwnerRegistrationGate =
+    !!address && publishingAsOwner && !agentLoading && !isRegisteredAndActive;
+
+  const showWizard = !address || !publishingAsOwner || isRegisteredAndActive;
 
   return (
     <main className="min-h-screen noise">
@@ -79,31 +127,87 @@ function PublishContent() {
         </div>
 
         <div className="max-w-5xl mx-auto">
-          {address && !agentLoading && !isRegisteredAndActive && (
+          {address && (
+            <div className="glow-card rounded-xl p-4 mb-6">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div>
+                  <label className="text-xs uppercase tracking-wide text-weavrn-muted block mb-1">
+                    Publish as
+                  </label>
+                  <select
+                    value={selected}
+                    onChange={(e) => setSelected(e.target.value)}
+                    className="bg-weavrn-dark border border-weavrn-border rounded-lg text-sm px-3 py-2 focus:outline-none focus:border-weavrn-accent/50 min-w-[260px]"
+                    data-testid="publish-as-select"
+                  >
+                    <option value={OWNER_OPTION}>
+                      My wallet ({truncAddr(address)})
+                    </option>
+                    {hostedAgents.map((a) => (
+                      <option key={a.wallet_address} value={a.wallet_address.toLowerCase()}>
+                        {a.agent_name || "Hosted agent"} ({truncAddr(a.wallet_address)})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                {!hostedLoaded && signer && (
+                  <button
+                    type="button"
+                    onClick={() => fetchHosted(address, signer)}
+                    disabled={hostedLoading}
+                    className="text-xs text-weavrn-accent hover:text-weavrn-accent-hover transition-colors disabled:opacity-50"
+                  >
+                    {hostedLoading ? "Loading..." : "Load my hosted agents"}
+                  </button>
+                )}
+              </div>
+              {hostedError && (
+                <p className="mt-2 text-xs text-red-400">{hostedError}</p>
+              )}
+              {hostedLoaded && hostedAgents.length === 0 && (
+                <p className="mt-2 text-xs text-weavrn-muted">
+                  No hosted agents found. Deploy one from the{" "}
+                  <a href="/dashboard" className="text-weavrn-accent hover:underline">
+                    dashboard
+                  </a>
+                  .
+                </p>
+              )}
+              {!publishingAsOwner && (
+                <p className="mt-2 text-xs text-weavrn-accent">
+                  Listing will be published under this hosted agent. Your connected wallet signs as the owner.
+                </p>
+              )}
+            </div>
+          )}
+
+          {showOwnerRegistrationGate && (
             <div className="mb-6">
               <div className="border border-yellow-500/40 rounded-lg p-3 text-xs text-yellow-400 bg-yellow-500/5 mb-4">
-                Your wallet must be registered as an active agent before you can publish tools.
+                Your wallet must be registered as an active agent before you can publish tools under it.
+                {hostedAgents.length > 0 && " Or switch to one of your hosted agents above."}
               </div>
               <AgentRegistration
                 agent={agent}
                 signer={signer}
-                onRegistered={() => fetchAgent(address)}
+                onRegistered={() => fetchAgent(address!)}
               />
             </div>
           )}
 
-          {agentLoading && address && (
+          {agentLoading && address && publishingAsOwner && (
             <div className="text-center text-sm text-weavrn-muted py-8">
               Checking agent registration...
             </div>
           )}
 
-          {(!address || isRegisteredAndActive) && (
+          {showWizard && (
             <ToolPublishWizard
               walletAddress={address}
               signer={signer}
               editListingId={editListingId}
               searchParams={new URLSearchParams(searchParams.toString())}
+              publishAsWallet={publishAsWallet}
             />
           )}
         </div>

--- a/src/components/ToolPublishWizard.tsx
+++ b/src/components/ToolPublishWizard.tsx
@@ -118,6 +118,14 @@ interface Props {
   signer: JsonRpcSigner | null;
   editListingId?: number | null;
   searchParams?: URLSearchParams | null;
+  /**
+   * Wallet to publish under. Defaults to `walletAddress` (the connected owner).
+   * When set to a different address (a hosted agent wallet owned by the
+   * connected wallet), the server persists the listing under that wallet
+   * via `agent_wallet` and checks its on-chain registration instead of the
+   * owner's.
+   */
+  publishAsWallet?: string | null;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1562,7 +1570,13 @@ export default function ToolPublishWizard({
   signer,
   editListingId,
   searchParams,
+  publishAsWallet,
 }: Props): JSX.Element {
+  const effectivePublishWallet = (publishAsWallet ?? walletAddress)?.toLowerCase() ?? null;
+  const isHostedAgentPublish =
+    !!effectivePublishWallet &&
+    !!walletAddress &&
+    effectivePublishWallet !== walletAddress.toLowerCase();
   const lsKey = walletAddress ? `${LS_PREFIX}${walletAddress.toLowerCase()}` : null;
 
   const [draft, setDraft] = useState<ToolDraft>(() => makeInitialDraft());
@@ -1716,12 +1730,15 @@ export default function ToolPublishWizard({
     setPublishError(null);
     try {
       const payload = buildPublishPayload(draft);
+      const payloadWithAgent = isHostedAgentPublish
+        ? { ...payload, agent_wallet: effectivePublishWallet }
+        : payload;
       if (isEdit && editIdRef.current) {
         await updateListing(
           signer,
           walletAddress,
           editIdRef.current,
-          payload as unknown as Partial<ServiceListing>,
+          payloadWithAgent as unknown as Partial<ServiceListing>,
         );
       } else {
         // createListing's declared shape omits many MCP keys. The server
@@ -1730,7 +1747,7 @@ export default function ToolPublishWizard({
         await createListing(
           signer,
           walletAddress,
-          payload as unknown as Parameters<typeof createListing>[2],
+          payloadWithAgent as unknown as Parameters<typeof createListing>[2],
         );
       }
       // Clear autosave and redirect.
@@ -1741,8 +1758,9 @@ export default function ToolPublishWizard({
           // ignore
         }
       }
+      const destinationWallet = effectivePublishWallet || walletAddress;
       const destination = `/tools/view?provider=${encodeURIComponent(
-        walletAddress,
+        destinationWallet,
       )}&slug=${encodeURIComponent(draft.mcp_tool_slug)}`;
       if (typeof window !== "undefined") {
         window.location.href = destination;
@@ -1754,7 +1772,7 @@ export default function ToolPublishWizard({
     } finally {
       setPublishing(false);
     }
-  }, [signer, walletAddress, draft, isEdit, lsKey]);
+  }, [signer, walletAddress, draft, isEdit, lsKey, isHostedAgentPublish, effectivePublishWallet]);
 
   return (
     <div className="max-w-3xl mx-auto space-y-4">
@@ -1828,7 +1846,7 @@ export default function ToolPublishWizard({
         <WizardBasicsStep
           draft={draft}
           setDraft={setDraft}
-          walletAddress={walletAddress}
+          walletAddress={effectivePublishWallet}
           slugState={slugState}
           setSlugState={setSlugState}
         />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -693,6 +693,36 @@ export async function deactivateListing(signer: import("ethers").JsonRpcSigner, 
   });
 }
 
+// ── Hosted Agents ──
+
+export interface HostedAgentSummary {
+  id: number;
+  wallet_address: string;
+  model_name: string;
+  system_prompt: string;
+  tier: "managed" | "byok";
+  active: boolean;
+  agent_name: string | null;
+  job_count: number;
+  created_at: string;
+}
+
+export async function getHostedAgents(
+  signer: import("ethers").JsonRpcSigner,
+  walletAddress: string,
+): Promise<HostedAgentSummary[]> {
+  if (!hasSession()) await createSession(signer, walletAddress);
+  const token = getSessionToken();
+  if (!token) throw new Error("No session token");
+  const res = await fetch(
+    `${API_URL}/hosted-agents?wallet_address=${walletAddress.toLowerCase()}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) throw new Error(`Failed to load hosted agents (${res.status})`);
+  const data = await res.json();
+  return data.agents || [];
+}
+
 // ── Jobs ──
 
 export interface Job {


### PR DESCRIPTION
## Summary

- Added "Publish as" selector to /tools/publish — users can publish listings under their connected wallet or any of their active hosted agents
- Wired ToolPublishWizard with optional publishAsWallet prop that routes slug check, agent_wallet payload field, and post publish redirect through the publish-as wallet
- Registration gate is now context-aware: only prompts for on-chain agent registration when publishing under the owner wallet and that wallet isn't registered. Hosted agents skip the gate since they're auto-registered at deploy time
- Added getHostedAgents API helper; reuses existing session-token flow (no extra signature if user already has a session)

## Test plan
- Connect an unregistered owner wallet — registration form shows, wizard hidden
- Select a hosted agent from "Publish as" dropdown — gate disappears, wizard activates
- Publish under hosted agent — listing created with agent_wallet set, redirect goes to /tools/view?provider=<hostedWallet>&slug=…
- Switch back to "My wallet" — if unregistered, gate reappears
- Disconnect wallet — selector and hosted agent list reset cleanly
- Existing 9 wizard tests still pass (npx vitest run ToolPublishWizard)
- npx next build green